### PR TITLE
max length is 127 of the item name

### DIFF
--- a/app/presenters/spree_paypal_checkout/order_presenter.rb
+++ b/app/presenters/spree_paypal_checkout/order_presenter.rb
@@ -4,6 +4,8 @@ module SpreePaypalCheckout
   class OrderPresenter
     include PaypalServerSdk
 
+    PAYPAL_ITEM_NAME_MAX_LENGTH = 127
+
     def initialize(order)
       @order = order
     end
@@ -40,7 +42,7 @@ module SpreePaypalCheckout
               ),
               items: order.line_items.map do |line_item|
                 Item.new(
-                  name: line_item.name[0...127],
+                  name: line_item.name.to_s[0...PAYPAL_ITEM_NAME_MAX_LENGTH],
                   unit_amount: Money.new(
                     currency_code: order.currency.upcase,
                     value: line_item.price.to_s

--- a/app/presenters/spree_paypal_checkout/order_presenter.rb
+++ b/app/presenters/spree_paypal_checkout/order_presenter.rb
@@ -40,7 +40,7 @@ module SpreePaypalCheckout
               ),
               items: order.line_items.map do |line_item|
                 Item.new(
-                  name: line_item.name,
+                  name: line_item.name[0...127],
                   unit_amount: Money.new(
                     currency_code: order.currency.upcase,
                     value: line_item.price.to_s

--- a/spec/presenters/spree_paypal_checkout/order_presenter_spec.rb
+++ b/spec/presenters/spree_paypal_checkout/order_presenter_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe SpreePaypalCheckout::OrderPresenter do
+  let(:order) { build_stubbed(:order, line_items: [line_item]) }
+  subject { described_class.new(order) }
+
+  context "line_item.name" do
+
+    context "when line_item.name is longer than 127 characters" do
+      let(:line_item) {
+        item = build_stubbed(:line_item)
+        allow(item).to receive(:name).and_return("A" * 200)
+        item
+      }
+
+      it "truncates to 127 characters" do
+        item = subject.to_json['body'].purchase_units[0].items.first
+        expect(item.name.length).to eq(127)
+      end
+    end
+
+    context "when line_item.name is exactly 127 characters" do
+      let(:line_item) {
+        item = build_stubbed(:line_item)
+        allow(item).to receive(:name).and_return("B" * 127)
+        item
+      }
+      it "does not truncate the name" do
+        item = subject.to_json['body'].purchase_units[0].items.first
+        expect(item.name).to eq("B" * 127)
+        item
+      end
+    end
+
+    context "when line_item.name is nil" do
+      let(:line_item) {
+        item = build_stubbed(:line_item)
+        allow(item).to receive(:name).and_return(nil)
+        item
+      }
+      it "handles nil without raising" do
+        subject.to_json['body'].purchase_units[0].items.first
+        expect { subject.to_json['body'].purchase_units[0].items.first }.not_to raise_error
+        expect(subject.to_json['body'].purchase_units[0].items.first.name).to be_nil.or eq("")
+      end
+    end
+  end
+end

--- a/spec/presenters/spree_paypal_checkout/order_presenter_spec.rb
+++ b/spec/presenters/spree_paypal_checkout/order_presenter_spec.rb
@@ -37,9 +37,8 @@ RSpec.describe SpreePaypalCheckout::OrderPresenter do
         item
       }
       it "handles nil without raising" do
-        subject.to_json['body'].purchase_units[0].items.first
         expect { subject.to_json['body'].purchase_units[0].items.first }.not_to raise_error
-        expect(subject.to_json['body'].purchase_units[0].items.first.name).to be_nil.or eq("")
+        expect(subject.to_json['body'].purchase_units[0].items.first.name).to eq("")
       end
     end
   end


### PR DESCRIPTION

<img width="1992" height="948" alt="image" src="https://github.com/user-attachments/assets/bbe6e20f-aeff-4925-9fd9-17b36294f262" />

https://developer.paypal.com/docs/api/orders/v2/#orders_create!ct=application/json&path=purchase_units/items/name&t=request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Product names in PayPal order summaries are now limited to 127 characters to ensure proper display and prevent errors during checkout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->