### PR TITLE
Fix payment source uniqueness violation on guest-to-user transition

### DIFF
--- a/app/models/spree/payment_sessions/paypal_checkout.rb
+++ b/app/models/spree/payment_sessions/paypal_checkout.rb
@@ -61,10 +61,10 @@ module Spree
 
       source = SpreePaypalCheckout::PaymentSources::Paypal.find_or_initialize_by(
         payment_method: payment_method,
-        user: order.user,
         gateway_payment_profile_id: paypal_data['account_id']
       )
       source.update!(
+        user: order.user,
         email: paypal_data['email_address'],
         name: "#{paypal_data.dig('name', 'given_name')} #{paypal_data.dig('name', 'surname')}".strip,
         account_id: paypal_data['account_id'],

--- a/app/services/spree_paypal_checkout/create_source.rb
+++ b/app/services/spree_paypal_checkout/create_source.rb
@@ -37,10 +37,10 @@ module SpreePaypalCheckout
     def create_paypal_source
       source = SpreePaypalCheckout::PaymentSources::Paypal.find_or_create_by!(
         payment_method: gateway,
-        user: user,
         gateway_payment_profile_id: paypal_payment_source['paypal']['account_id']
       )
       source.update!(
+        user: user,
         email: paypal_payment_source['paypal']['email_address'],
         name: "#{paypal_payment_source['paypal']['name']['given_name']} #{paypal_payment_source['paypal']['name']['surname']}".strip,
         account_id: paypal_payment_source['paypal']['account_id'],

--- a/spec/models/spree/payment_sessions/paypal_checkout_spec.rb
+++ b/spec/models/spree/payment_sessions/paypal_checkout_spec.rb
@@ -75,6 +75,45 @@ RSpec.describe Spree::PaymentSessions::PaypalCheckout do
       expect { session.find_or_create_payment! }.not_to change(Spree::Payment, :count)
     end
 
+    context 'when guest checks out then signs in (user changes)' do
+      let(:guest_order) { create(:order_with_line_items, store: store, user: nil) }
+      let(:session) { create(:paypal_checkout_payment_session, order: guest_order, payment_method: gateway, external_data: captured_data) }
+
+      it 'creates a payment source without a user' do
+        payment = session.find_or_create_payment!
+        expect(payment.source).to be_a(SpreePaypalCheckout::PaymentSources::Paypal)
+        expect(payment.source.user).to be_nil
+      end
+
+      it 'reuses the same payment source when user is later associated' do
+        # First checkout as guest
+        payment = session.find_or_create_payment!
+        source = payment.source
+
+        # Simulate guest signing in - order now has a user
+        guest_order.update!(user: user)
+
+        # New session for a second order by the now-signed-in user
+        second_order = create(:order_with_line_items, store: store, user: user)
+        second_session = create(:paypal_checkout_payment_session, order: second_order, payment_method: gateway, external_data: captured_data)
+
+        second_payment = second_session.find_or_create_payment!
+        expect(second_payment.source).to eq(source)
+        expect(second_payment.source.user).to eq(user)
+      end
+
+      it 'does not raise a uniqueness violation when user changes' do
+        # First checkout as guest
+        session.find_or_create_payment!
+
+        # Second checkout with a user using the same PayPal account
+        user_order = create(:order_with_line_items, store: store, user: user)
+        user_session = create(:paypal_checkout_payment_session, order: user_order, payment_method: gateway, external_data: captured_data)
+
+        expect { user_session.find_or_create_payment! }.not_to raise_error
+      end
+    end
+
     context 'when payment_source data is not present' do
       let(:session) { create(:paypal_checkout_payment_session, order: order, payment_method: gateway, external_data: captured_data.except('payment_source')) }
 

--- a/spec/services/spree_paypal_checkout/create_source_spec.rb
+++ b/spec/services/spree_paypal_checkout/create_source_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+RSpec.describe SpreePaypalCheckout::CreateSource do
+  let(:store) { create(:store) }
+  let(:gateway) { create(:paypal_checkout_gateway, stores: [store]) }
+  let(:user) { create(:user) }
+  let(:order) { create(:order_with_line_items, store: store, user: user) }
+
+  let(:paypal_payment_source) do
+    {
+      'paypal' => {
+        'email_address' => 'sb-fxqy4743082799@personal.example.com',
+        'account_id' => 'RX8ZD67CZ67RU',
+        'account_status' => 'VERIFIED',
+        'name' => {
+          'given_name' => 'John',
+          'surname' => 'Doe'
+        }
+      }
+    }
+  end
+
+  describe '#call' do
+    subject { described_class.new(paypal_payment_source: paypal_payment_source, gateway: gateway, order: order).call }
+
+    it 'creates a PayPal payment source' do
+      expect { subject }.to change(SpreePaypalCheckout::PaymentSources::Paypal, :count).by(1)
+    end
+
+    it 'sets the correct attributes' do
+      source = subject
+      expect(source.email).to eq('sb-fxqy4743082799@personal.example.com')
+      expect(source.account_id).to eq('RX8ZD67CZ67RU')
+      expect(source.account_status).to eq('VERIFIED')
+      expect(source.name).to eq('John Doe')
+      expect(source.user).to eq(user)
+      expect(source.payment_method).to eq(gateway)
+      expect(source.gateway_payment_profile_id).to eq('RX8ZD67CZ67RU')
+    end
+
+    it 'reuses existing source for the same PayPal account and gateway' do
+      described_class.new(paypal_payment_source: paypal_payment_source, gateway: gateway, order: order).call
+      expect { subject }.not_to change(SpreePaypalCheckout::PaymentSources::Paypal, :count)
+    end
+
+    context 'when guest checks out then signs in' do
+      let(:guest_order) { create(:order_with_line_items, store: store, user: nil) }
+
+      it 'does not raise a uniqueness violation' do
+        # Guest checkout - source created without user
+        described_class.new(paypal_payment_source: paypal_payment_source, gateway: gateway, order: guest_order).call
+
+        # Same PayPal account, now with a signed-in user
+        expect {
+          described_class.new(paypal_payment_source: paypal_payment_source, gateway: gateway, order: order, user: user).call
+        }.not_to raise_error
+      end
+
+      it 'associates the user to the existing source' do
+        source = described_class.new(paypal_payment_source: paypal_payment_source, gateway: gateway, order: guest_order).call
+        expect(source.user).to be_nil
+
+        source = described_class.new(paypal_payment_source: paypal_payment_source, gateway: gateway, order: order, user: user).call
+        expect(source.user).to eq(user)
+      end
+
+      it 'reuses the same source record' do
+        guest_source = described_class.new(paypal_payment_source: paypal_payment_source, gateway: gateway, order: guest_order).call
+        user_source = described_class.new(paypal_payment_source: paypal_payment_source, gateway: gateway, order: order, user: user).call
+
+        expect(user_source.id).to eq(guest_source.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Removed `user` from `find_or_initialize_by` / `find_or_create_by` lookup when creating PayPal payment sources
- The DB unique index is on `[:type, :gateway_payment_profile_id]`, but including `user` in the lookup caused it to miss existing records when a guest later signed in (user changed from `nil` to a real user), triggering a uniqueness violation
- The `user` association is now set via `update!` instead, so the source is found by `payment_method` + `account_id` (matching the DB constraint) and the user gets associated on each use

## Changed files
- `app/models/spree/payment_sessions/paypal_checkout.rb` — `create_payment_source!`
- `app/services/spree_paypal_checkout/create_source.rb` — `create_paypal_source`

## Test plan
- [x] Added regression tests for guest-to-user transition in `PaymentSessions::PaypalCheckout` spec (3 new examples)
- [x] Added new `CreateSource` service spec with guest-to-user transition coverage (6 new examples)
- [x] Full test suite passes (85 examples, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved PayPal payment source handling to properly support guest-to-signed-in user transitions, ensuring the same payment source is reused when a guest checkout is later completed by a signed-in user.

* **Tests**
  * Added comprehensive test coverage for PayPal payment source creation and guest checkout flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->