### PR TITLE
Update PayPal setup tooltip with correct developer dashboard …

### DIFF
--- a/app/views/spree/admin/payment_methods/configuration_guides/_spree_paypal_checkout.html.erb
+++ b/app/views/spree/admin/payment_methods/configuration_guides/_spree_paypal_checkout.html.erb
@@ -1,6 +1,7 @@
 <div class="alert alert-info">
   <p class="mb-0">
     To find your <strong>Client ID</strong> and <strong>Client Secret</strong>, go to the 
-    <%= external_link_to 'PayPal dashboard', 'https://www.paypal.com/mep/merchantapps/setup/checkout/apicredentials', class: 'alert-link' %>
+    <%= external_link_to 'PayPal Developer Dashboard', 'https://developer.paypal.com/dashboard/', class: 'alert-link' %>.
+    For more information, see the <%= external_link_to 'PayPal REST API documentation', 'https://developer.paypal.com/api/rest/', class: 'alert-link' %>.
   </p>
 </div>


### PR DESCRIPTION
This MR changes the text blurb at the top of the paypal setup, to correct the links to the paypal developer docs and to add another link for the user to get more information about setting up an integration.

<img width="825" height="169" alt="Screenshot 2026-05-22 at 2 36 17 p m" src="https://github.com/user-attachments/assets/43024e0b-5fe6-4790-a0eb-65dbe1dc6638" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the PayPal Client ID / Client Secret configuration guide with a new PayPal Developer Dashboard link and improved link formatting in the admin panel.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spree/spree_paypal_checkout/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->