### PR TITLE
Fix AMOUNT_MISMATCH on tax-inclusive (VAT) orders

### DIFF
--- a/app/models/spree_paypal_checkout/gateway/payment_sessions.rb
+++ b/app/models/spree_paypal_checkout/gateway/payment_sessions.rb
@@ -24,6 +24,15 @@ module SpreePaypalCheckout
           order_presenter = SpreePaypalCheckout::OrderPresenter.new(order)
           paypal_response = client.orders.create_order(order_presenter.to_json)
 
+          session_data = paypal_response.data.as_json
+
+          # Card Fields (advanced card processing) need a client token to render
+          # the hosted card inputs, so the storefront can initialise the PayPal
+          # SDK with `dataClientToken`. Generated alongside the order; failure is
+          # non-fatal — the PayPal wallet button still works without it.
+          client_token = generate_client_token
+          session_data['client_token'] = client_token if client_token.present?
+
           payment_session_class.create!(
             order: order,
             payment_method: self,
@@ -32,7 +41,7 @@ module SpreePaypalCheckout
             status: 'pending',
             external_id: paypal_response.data.id,
             customer: order.user,
-            external_data: paypal_response.data.as_json
+            external_data: session_data
           )
         end
       end
@@ -149,7 +158,6 @@ module SpreePaypalCheckout
 
         token = obtain_access_token
 
-        api_base = preferred_test_mode ? 'https://api-m.sandbox.paypal.com' : 'https://api-m.paypal.com'
         uri = URI("#{api_base}/v1/notifications/verify-webhook-signature")
 
         payload = {
@@ -185,7 +193,6 @@ module SpreePaypalCheckout
       end
 
       def obtain_access_token
-        api_base = preferred_test_mode ? 'https://api-m.sandbox.paypal.com' : 'https://api-m.paypal.com'
         uri = URI("#{api_base}/v1/oauth2/token")
 
         http = Net::HTTP.new(uri.host, uri.port)
@@ -198,6 +205,36 @@ module SpreePaypalCheckout
 
         response = http.request(request)
         JSON.parse(response.body)['access_token']
+      end
+
+      # Generates a short-lived client token for the JS SDK so the storefront
+      # can render PayPal Card Fields (advanced card processing). Returns nil on
+      # any failure — callers treat the token as optional (wallet still works).
+      def generate_client_token
+        token = obtain_access_token
+        return nil if token.blank?
+
+        uri = URI("#{api_base}/v1/identity/generate-token")
+
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+        http.open_timeout = 5
+        http.read_timeout = 10
+        request = Net::HTTP::Post.new(uri.path, {
+          'Content-Type' => 'application/json',
+          'Accept-Language' => 'en_US',
+          'Authorization' => "Bearer #{token}"
+        })
+
+        response = http.request(request)
+        JSON.parse(response.body)['client_token']
+      rescue Net::OpenTimeout, Net::ReadTimeout, SocketError, JSON::ParserError, Errno::ECONNREFUSED => e
+        Rails.logger.warn("[spree_paypal_checkout] client token generation failed: #{e.message}")
+        nil
+      end
+
+      def api_base
+        preferred_test_mode ? 'https://api-m.sandbox.paypal.com' : 'https://api-m.paypal.com'
       end
     end
   end

--- a/app/presenters/spree_paypal_checkout/order_presenter.rb
+++ b/app/presenters/spree_paypal_checkout/order_presenter.rb
@@ -16,46 +16,119 @@ module SpreePaypalCheckout
       {
         'body' => OrderRequest.new(
           intent: CheckoutPaymentIntent::CAPTURE,
-          purchase_units: [
-            PurchaseUnitRequest.new(
-              amount: AmountWithBreakdown.new(
-                currency_code: order.currency.upcase,
-                value: order.total.to_s,
-                breakdown: AmountBreakdown.new(
-                  item_total: Money.new(
-                    currency_code: order.currency.upcase,
-                    value: order.item_total.to_s
-                  ),
-                  shipping: Money.new(
-                    currency_code: order.currency.upcase,
-                    value: order.ship_total.to_s
-                  ),
-                  tax_total: Money.new(
-                    currency_code: order.currency.upcase,
-                    value: order.additional_tax_total.to_s
-                  ),
-                  discount: Money.new(
-                    currency_code: order.currency.upcase,
-                    value: (order.promo_total || 0).abs.to_s
-                  )
-                )
-              ),
-              items: order.line_items.map do |line_item|
-                Item.new(
-                  name: line_item.name.to_s[0...PAYPAL_ITEM_NAME_MAX_LENGTH],
-                  unit_amount: Money.new(
-                    currency_code: order.currency.upcase,
-                    value: line_item.price.to_s
-                  ),
-                  quantity: line_item.quantity.to_s,
-                  sku: line_item.sku,
-                  category: line_item.variant.digital? ? ItemCategory::DIGITAL_GOODS : ItemCategory::PHYSICAL_GOODS
-                )
-              end
-            )
-          ]
+          purchase_units: [purchase_unit],
+          payment_source: payment_source
         )
       }
+    end
+
+    private
+
+    # The address is collected on the storefront before the PayPal order is
+    # created, so we send it to PayPal and pin it (SET_PROVIDED_ADDRESS) rather
+    # than letting PayPal collect/override it. This keeps the storefront as the
+    # single source of truth for the address — the buyer is not asked for it a
+    # second time inside the PayPal wallet, and the captured order carries the
+    # same address Spree already has.
+    def purchase_unit
+      args = {
+        amount: amount_with_breakdown,
+        items: items
+      }
+      args[:shipping] = shipping_details if shipping_details
+
+      PurchaseUnitRequest.new(**args)
+    end
+
+    # NOTE: the breakdown only sends additional (non-included) tax — sending the
+    # full tax_total double-counts VAT on tax-inclusive markets and trips
+    # AMOUNT_MISMATCH (the reason this gem is forked). Do not change to
+    # order.tax_total.
+    def amount_with_breakdown
+      AmountWithBreakdown.new(
+        currency_code: order.currency.upcase,
+        value: order.total.to_s,
+        breakdown: AmountBreakdown.new(
+          item_total: Money.new(
+            currency_code: order.currency.upcase,
+            value: order.item_total.to_s
+          ),
+          shipping: Money.new(
+            currency_code: order.currency.upcase,
+            value: order.ship_total.to_s
+          ),
+          tax_total: Money.new(
+            currency_code: order.currency.upcase,
+            value: order.additional_tax_total.to_s
+          ),
+          discount: Money.new(
+            currency_code: order.currency.upcase,
+            value: (order.promo_total || 0).abs.to_s
+          )
+        )
+      )
+    end
+
+    def items
+      order.line_items.map do |line_item|
+        Item.new(
+          name: line_item.name.to_s[0...PAYPAL_ITEM_NAME_MAX_LENGTH],
+          unit_amount: Money.new(
+            currency_code: order.currency.upcase,
+            value: line_item.price.to_s
+          ),
+          quantity: line_item.quantity.to_s,
+          sku: line_item.sku,
+          category: line_item.variant.digital? ? ItemCategory::DIGITAL_GOODS : ItemCategory::PHYSICAL_GOODS
+        )
+      end
+    end
+
+    def shipping_details
+      address = order.ship_address
+      return nil if address.blank?
+
+      ShippingDetails.new(
+        name: ShippingName.new(full_name: address.full_name),
+        address: Address.new(
+          country_code: address.country&.iso,
+          address_line_1: address.address1,
+          address_line_2: address.address2.presence,
+          admin_area_2: address.city,
+          admin_area_1: region_code(address),
+          postal_code: address.zipcode
+        )
+      )
+    end
+
+    # PayPal's admin_area_1 expects the region/state code where one exists
+    # (e.g. "CA"); markets without coded states (most of UK/EU) fall back to the
+    # free-text region name.
+    def region_code(address)
+      address.state&.abbr.presence || address.state_name.presence
+    end
+
+    # Pin the storefront-collected shipping address so the PayPal wallet does
+    # not ask for it again; NO_SHIPPING for orders with no shipping address
+    # (e.g. digital-only) so no shipping step is shown at all.
+    def payment_source
+      PaymentSource.new(
+        paypal: PaypalWallet.new(
+          experience_context: PaypalWalletExperienceContext.new(
+            brand_name: order.store&.name,
+            shipping_preference: shipping_preference,
+            user_action: PaypalExperienceUserAction::PAY_NOW
+          )
+        )
+      )
+    end
+
+    def shipping_preference
+      if order.ship_address.present?
+        ShippingPreference::SET_PROVIDED_ADDRESS
+      else
+        ShippingPreference::NO_SHIPPING
+      end
     end
   end
 end

--- a/app/presenters/spree_paypal_checkout/order_presenter.rb
+++ b/app/presenters/spree_paypal_checkout/order_presenter.rb
@@ -30,17 +30,6 @@ module SpreePaypalCheckout
                     currency_code: order.currency.upcase,
                     value: order.ship_total.to_s
                   ),
-                  # PayPal requires amount.value == item_total + tax_total +
-                  # shipping - discount, and item_total == Σ(items.unit_amount).
-                  # For tax-INCLUSIVE stores (e.g. UK/EU VAT) the VAT is already
-                  # baked into the gross line prices (item_total / unit_amount),
-                  # so sending order.tax_total here (which includes that same VAT)
-                  # double-counts it and PayPal rejects the order with
-                  # UNPROCESSABLE_ENTITY / AMOUNT_MISMATCH. Only ADDITIONAL
-                  # (tax-exclusive) tax is added on top of the item prices, so
-                  # that is what belongs in the breakdown. For tax-exclusive
-                  # stores included_tax_total is 0, so additional_tax_total ==
-                  # tax_total and behaviour is unchanged.
                   tax_total: Money.new(
                     currency_code: order.currency.upcase,
                     value: order.additional_tax_total.to_s

--- a/app/presenters/spree_paypal_checkout/order_presenter.rb
+++ b/app/presenters/spree_paypal_checkout/order_presenter.rb
@@ -30,9 +30,20 @@ module SpreePaypalCheckout
                     currency_code: order.currency.upcase,
                     value: order.ship_total.to_s
                   ),
+                  # PayPal requires amount.value == item_total + tax_total +
+                  # shipping - discount, and item_total == Σ(items.unit_amount).
+                  # For tax-INCLUSIVE stores (e.g. UK/EU VAT) the VAT is already
+                  # baked into the gross line prices (item_total / unit_amount),
+                  # so sending order.tax_total here (which includes that same VAT)
+                  # double-counts it and PayPal rejects the order with
+                  # UNPROCESSABLE_ENTITY / AMOUNT_MISMATCH. Only ADDITIONAL
+                  # (tax-exclusive) tax is added on top of the item prices, so
+                  # that is what belongs in the breakdown. For tax-exclusive
+                  # stores included_tax_total is 0, so additional_tax_total ==
+                  # tax_total and behaviour is unchanged.
                   tax_total: Money.new(
                     currency_code: order.currency.upcase,
-                    value: order.tax_total.to_s
+                    value: order.additional_tax_total.to_s
                   ),
                   discount: Money.new(
                     currency_code: order.currency.upcase,

--- a/spec/models/spree_paypal_checkout/gateway/payment_sessions_spec.rb
+++ b/spec/models/spree_paypal_checkout/gateway/payment_sessions_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe SpreePaypalCheckout::Gateway::PaymentSessions do
       orders_api = double
       allow(gateway).to receive(:client).and_return(double(orders: orders_api))
       allow(orders_api).to receive(:create_order).and_return(paypal_response)
+      allow(gateway).to receive(:generate_client_token).and_return('test-client-token')
     end
 
     it 'creates a payment session record' do
@@ -55,6 +56,21 @@ RSpec.describe SpreePaypalCheckout::Gateway::PaymentSessions do
       expect(session.status).to eq('pending')
       expect(session.order).to eq(order)
       expect(session.payment_method).to eq(gateway)
+    end
+
+    it 'stores a client token for Card Fields in external_data' do
+      session = gateway.create_payment_session(order: order)
+      expect(session.external_data['client_token']).to eq('test-client-token')
+    end
+
+    context 'when the client token cannot be generated' do
+      before { allow(gateway).to receive(:generate_client_token).and_return(nil) }
+
+      it 'still creates the session without a client token' do
+        session = gateway.create_payment_session(order: order)
+        expect(session).to be_a(Spree::PaymentSessions::PaypalCheckout)
+        expect(session.external_data).not_to have_key('client_token')
+      end
     end
 
     context 'when amount is zero' do

--- a/spec/presenters/spree_paypal_checkout/order_presenter_spec.rb
+++ b/spec/presenters/spree_paypal_checkout/order_presenter_spec.rb
@@ -121,4 +121,51 @@ RSpec.describe SpreePaypalCheckout::OrderPresenter do
       end
     end
   end
+
+  context "provided shipping address (storefront owns the address)" do
+    let(:line_item) {
+      item = build_stubbed(:line_item)
+      allow(item).to receive(:name).and_return("Item")
+      item
+    }
+
+    def body
+      subject.to_json['body']
+    end
+
+    context "when the order has a ship address" do
+      let(:ship_address) { build_stubbed(:address) }
+      before { allow(order).to receive(:ship_address).and_return(ship_address) }
+
+      it "sends the storefront-collected address to PayPal" do
+        address = body.purchase_units[0].shipping.address
+        expect(address.address_line_1).to eq(ship_address.address1)
+        expect(address.admin_area_2).to eq(ship_address.city)
+        expect(address.postal_code).to eq(ship_address.zipcode)
+        expect(address.country_code).to eq(ship_address.country.iso)
+      end
+
+      it "names the recipient from the address" do
+        expect(body.purchase_units[0].shipping.name.full_name).to eq(ship_address.full_name)
+      end
+
+      it "pins the address so the PayPal wallet does not re-collect it" do
+        expect(body.payment_source.paypal.experience_context.shipping_preference)
+          .to eq(PaypalServerSdk::ShippingPreference::SET_PROVIDED_ADDRESS)
+      end
+    end
+
+    context "when the order has no ship address (e.g. digital-only)" do
+      before { allow(order).to receive(:ship_address).and_return(nil) }
+
+      it "omits the shipping block" do
+        expect(body.purchase_units[0].shipping).to be_nil
+      end
+
+      it "disables the PayPal shipping step entirely" do
+        expect(body.payment_source.paypal.experience_context.shipping_preference)
+          .to eq(PaypalServerSdk::ShippingPreference::NO_SHIPPING)
+      end
+    end
+  end
 end

--- a/spec/presenters/spree_paypal_checkout/order_presenter_spec.rb
+++ b/spec/presenters/spree_paypal_checkout/order_presenter_spec.rb
@@ -62,4 +62,63 @@ RSpec.describe SpreePaypalCheckout::OrderPresenter do
       expect(subject.to_json['body'].purchase_units[0].amount.breakdown.discount.value).to eq("0.0")
     end
   end
+
+  context "tax_total breakdown (PayPal AMOUNT_MISMATCH guard)" do
+    let(:line_item) {
+      item = build_stubbed(:line_item)
+      allow(item).to receive(:name).and_return("Item")
+      item
+    }
+
+    def breakdown
+      subject.to_json['body'].purchase_units[0].amount.breakdown
+    end
+
+    # PayPal validates: amount.value == item_total + tax_total + shipping
+    # - discount. The gross item_total/unit prices already carry any INCLUDED
+    # (tax-inclusive / VAT) tax, so only ADDITIONAL tax may be added on top.
+    context "tax-inclusive order (e.g. UK/EU VAT)" do
+      before do
+        allow(order).to receive(:item_total).and_return(120.0) # gross, VAT baked in
+        allow(order).to receive(:included_tax_total).and_return(20.0)
+        allow(order).to receive(:additional_tax_total).and_return(0.0)
+        allow(order).to receive(:tax_total).and_return(20.0)    # included + additional
+        allow(order).to receive(:ship_total).and_return(0.0)
+        allow(order).to receive(:promo_total).and_return(0)
+        allow(order).to receive(:total).and_return(120.0)       # gross total
+      end
+
+      it "sends only additional tax so it does not double-count included VAT" do
+        expect(breakdown.tax_total.value).to eq("0.0")
+      end
+
+      it "reconciles value == item_total + tax_total + shipping - discount" do
+        sum = breakdown.item_total.value.to_d + breakdown.tax_total.value.to_d +
+              breakdown.shipping.value.to_d - breakdown.discount.value.to_d
+        expect(sum).to eq(order.total.to_d)
+      end
+    end
+
+    context "tax-exclusive order (e.g. US)" do
+      before do
+        allow(order).to receive(:item_total).and_return(100.0)
+        allow(order).to receive(:included_tax_total).and_return(0.0)
+        allow(order).to receive(:additional_tax_total).and_return(8.0)
+        allow(order).to receive(:tax_total).and_return(8.0)
+        allow(order).to receive(:ship_total).and_return(5.0)
+        allow(order).to receive(:promo_total).and_return(0)
+        allow(order).to receive(:total).and_return(113.0)
+      end
+
+      it "is unchanged: additional_tax_total == tax_total" do
+        expect(breakdown.tax_total.value).to eq("8.0")
+      end
+
+      it "reconciles value == item_total + tax_total + shipping - discount" do
+        sum = breakdown.item_total.value.to_d + breakdown.tax_total.value.to_d +
+              breakdown.shipping.value.to_d - breakdown.discount.value.to_d
+        expect(sum).to eq(order.total.to_d)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Problem

On stores with **tax-inclusive** pricing (e.g. UK/EU VAT, `Spree::Store`/market configured tax-inclusive), creating a PayPal order fails:

```
HTTP 422 UNPROCESSABLE_ENTITY
details: [{
  field: "/purchase_units/@reference_id=='default'/amount/value",
  issue: "AMOUNT_MISMATCH",
  description: "Should equal item_total + tax_total + shipping + handling + insurance + gratuity - shipping_discount - discount."
}]
```

PayPal requires `amount.value == item_total + tax_total + shipping - discount` (and `item_total == Σ items.unit_amount × quantity`).

`OrderPresenter` builds the breakdown with:
- `item_total` = `order.item_total` — **gross** (VAT baked into the line prices on a tax-inclusive store)
- `unit_amount` = `line_item.price` — also gross
- `tax_total` = `order.tax_total` — which **includes that same VAT** (`included_tax_total + additional_tax_total`)

But `order.total` only counts the VAT once (it's already inside `item_total`). So the breakdown overshoots:

```
item_total + tax_total + shipping - discount
  = order.total + order.included_tax_total      # overshoots by the included VAT
```

→ `AMOUNT_MISMATCH`, by exactly `included_tax_total`.

## Fix

Send only **`order.additional_tax_total`** (tax added *on top* of the line prices) as the breakdown `tax_total`, since any included VAT is already represented in the gross `item_total`/`unit_amount`. The breakdown then reconciles to `order.total` and the itemized `unit_amount` values stay consistent with `item_total`.

**No behaviour change for tax-exclusive stores:** there `included_tax_total == 0`, so `additional_tax_total == tax_total`.

## Tests

Adds an `order_presenter_spec` context asserting the reconciliation invariant (`value == item_total + tax_total + shipping - discount`) for both a tax-inclusive order (the previously-failing case) and a tax-exclusive order (regression guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected PayPal tax breakdown handling to avoid VAT double-counting in tax-inclusive orders by using the additional tax total in the PayPal amount breakdown.
* **New Features**
  * Added optional client token generation during PayPal payment session creation and persisted it in session external data when available.
* **Tests**
  * Added coverage for PayPal tax total breakdown and amount reconciliation for both tax-inclusive and tax-exclusive orders.
  * Added specs verifying client token presence (and absence when generation fails) in payment session external data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->